### PR TITLE
Updated post

### DIFF
--- a/blog/2021-08/constructing-build-information/index.md
+++ b/blog/2021-08/constructing-build-information/index.md
@@ -74,7 +74,7 @@ Repeat the **Add variable** process from above for the Octopus variables.  This 
 - Octopus Deploy Space Name
 
 ### Build YAML
-For GitLab, builds are defined using YAML in a special file, `.gitlab-ci.yml` located in the root of your repository.  Your process will consist of a `before_script` and two stages:
+For GitLab, builds are defined using YAML in a special file, `.gitlab-ci.yml` located in the root of your repository.  Your process will consist of two stages:
 
 - build-information
 - push-build-information


### PR DESCRIPTION
# About

The construct build information post had a section that referred to a before_script.  Originally, the post used a before_script in the GitLab definition, however, that was later removed before publish when the OctopusLabs CLI docker image became available.  I removed the content of the before_script from the post prior to publish, but it looks like I missed where it was mentioned in the text.

# Release

Is this post for a specific release? If so which one?

# Blog image idea

The design team will work on a design for the blog image. Add any ideas you have about the graphic image here.

# Pre-requisites

- [ ] The draft is complete and this post is ready to be reviewed.
- [ ] I'm familiar with the [writing for Octopus TL;DR](https://style.octopus.com/writing-at-octopus-tldr).
- [ ] The PR build passes validation, and if it doesn't, I've checked the [common validations errors](https://style.octopus.com/writing-at-octopus-tldr#common-validation-errors) and none of those apply.
- [ ] The images I've included follow the [rules for working with images](https://style.octopus.com/images#rules-for-screenshots).

## How to review this PR
<!-- If there's anything you'd like reviewers to focus on, mention it here. -->


## Publication date
<!-- if there are considerations for when to publish this post, mention that here. i.e., this post is supporting material for a webinar I'll be conducting on date, or this post should not published until after a specific release -->

