### PR TITLE
Proposed include for 2021 Q3 posts

### DIFF
--- a/blog/2021-09/google-cloud-platform-integration/index.md
+++ b/blog/2021-09/google-cloud-platform-integration/index.md
@@ -33,6 +33,8 @@ Built-in integration of Octopus with GCP allows you to:
 
 GCP integration is available in Octopus Deploy 2021.2 and newer. Octopus Cloud customers are already running this version, and on-premises customers can [download it now](https://octopus.com/downloads).
 
+!include <octopus-2021-q3>
+
 ## How to deploy to Google Cloud
 
 To see this new integration in action, this post explains how to add a new Google Cloud account in Octopus, and run a `gcloud` script to create a new Kubernetes cluster.

--- a/blog/2021-09/introducing-workato-connector/index.md
+++ b/blog/2021-09/introducing-workato-connector/index.md
@@ -30,6 +30,8 @@ The Workato connector for Octopus lets you quickly integrate Octopus with your w
 
 Additional actions can also be added to the connector if you need them.
 
+!include <octopus-2021-q3>
+
 ## Getting started
 
 Creating workflows in Workato with the Octopus Deploy connector is simple:

--- a/blog/2021-09/variable-run-conditions-with-octostache/index.md
+++ b/blog/2021-09/variable-run-conditions-with-octostache/index.md
@@ -16,6 +16,8 @@ One feature of Octopus Deploy I love using is [variable run conditions](https://
 
 In our 2021.2 release, the filters `Match` and `Contains` [were added to Octostache](https://octopus.com/docs/projects/variables/variable-filters#VariableSubstitutionSyntax-ComparisonFilters).  
 
+!include <octopus-2021-q3>
+
 In this post, I walk you through how to combine variable run conditions with output variables and the new `Contains` filter.
 
 ## The scenario

--- a/blog/2021-10/getting-started-with-ldap-auth-provider/index.md
+++ b/blog/2021-10/getting-started-with-ldap-auth-provider/index.md
@@ -12,7 +12,9 @@ tags:
  - Product
 ---
 
-In Octopus Deploy 2021.2, we added the [Lightweight Directory Access Protocol (LDAP)](https://ldap.com/) authentication provider.  
+In Octopus Deploy 2021.2, we added the [Lightweight Directory Access Protocol (LDAP)](https://ldap.com/) authentication provider. 
+
+!include <octopus-2021-q3>
 
 Many customers want to migrate to the Octopus Linux Container, but they have to authenticate via Active Directory.  Active Directory is also an LDAP server, meaning with the new LDAP provider you can now use the Octopus Linux Container **and** authenticate to Active Directory.  
 

--- a/blog/shared/octopus-2021-q3.include.md
+++ b/blog/shared/octopus-2021-q3.include.md
@@ -1,0 +1,1 @@
+Learn more about the Octopus 2021.2 (Q3) release in our [release announcement](https://octopus.com/blog/octopus-release-2021-q3).


### PR DESCRIPTION
This PR adds a link to the Octopus 2021 Q3 announcement from the other Q3 posts.

I considered using :::hint::: formatting, but the intro to Bob's LDAP post already contains a hint. It may look funny to have two so close together.

Initially, I placed the include at the end of the intro for each post. I'm happy to run with that approach if it's preferred. (I'm not sure we should be placing this ahead of every introduction, particularly if it's not formatted as a hint or the like.)