### PR TITLE
Add VS Code extension link

### DIFF
--- a/blog/2021-12/octopus-release-2021-q4/index.md
+++ b/blog/2021-12/octopus-release-2021-q4/index.md
@@ -98,7 +98,7 @@ The Configuration as Code early access preview (EAP) is available to all custome
 
 ![The branch selector on the deployment process page in Octopus Deploy](octopus-config-as-code-branch-selector.png)
 
-Octopus Deploy for Visual Studio Code is a free extension that makes working with Octopus Configuration Language (OCL) files easier. Features include:
+[Octopus Deploy for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=octopusdeploy.vscode-octopusdeploy) is a free extension that makes working with Octopus Configuration Language (OCL) files easier. Features include:
 
 - Syntax highlighting
 - Code snippets for steps and actions


### PR DESCRIPTION
I added a link to our VS Code extension in the marketplace, consistent with the CaC EAP announcement.

I'm raising this change on a branch as a precaution; it's late in the day, and I'm tired. 😂 