### PR TITLE
Add latest blog post to intro list for EKS cluster post

### DIFF
--- a/blog/2022-02/eks-cluster-aws/index.md
+++ b/blog/2022-02/eks-cluster-aws/index.md
@@ -159,6 +159,7 @@ EKS on AWS allows you to provision Kubernetes services in the cloud to deploy an
 The clusters you created can be used to set up web applications and as part of workflows in upcoming posts. We'll add links to the relevant posts as they become available:
 
 - [Building a Docker image in Jenkinsfile and publishing to ECR](https://octopus.com/blog/jenkins-docker-ecr)
+- [Deploying to Amazon EKS with Docker and Jenkins](https://octopus.com/blog/jenkins-eks-ecr-deployment)
 
 !include <q1-2022-newsletter-cta>
 

--- a/blog/2022-02/eks-cluster-aws/index.md
+++ b/blog/2022-02/eks-cluster-aws/index.md
@@ -23,6 +23,7 @@ EKS is a managed container service to run and scale Kubernetes in the cloud or o
 The clusters you create in this post will be used in later posts in our [Continuous Integration series](https://octopus.com/blog/tag/CI%20Series), to set up web applications and as part of workflows. We'll add links to the relevant posts as they become available:
 
 - [Building a Docker image in Jenkinsfile and publishing to ECR](https://octopus.com/blog/jenkins-docker-ecr)
+- [Deploying to Amazon EKS with Docker and Jenkins](https://octopus.com/blog/jenkins-eks-ecr-deployment)
 
 ## Prerequisites
 


### PR DESCRIPTION
I'm queueing up the follow-up tweets for the latest post from Terence and noticed it's not in the list in the create clusters post. I nearly pinged you via Slack, but maybe this is more helpful. 🤗 