### PR TITLE
Ruby syntax highlighting for OCL / HCL

### DIFF
--- a/blog/2020-11/shaping-config-as-code/index.md
+++ b/blog/2020-11/shaping-config-as-code/index.md
@@ -159,7 +159,7 @@ From this point, your release doesn’t change as it progresses through the envi
 
 For our configuration language, we are using a language based on [Hashicorp’s HCL](https://github.com/hashicorp/hcl).  
 
-```hcl
+```ruby
 step "Greetings World" {
     script_action {
         channels = ["Release", "Beta"]


### PR DESCRIPTION
# About

Following on from the syntax highlighting addition here: https://github.com/OctopusDeploy/Octofront/pull/4022

We can now highlight HCL and OCL in blog posts, using the "ruby" syntax highlighter.

# Release

This is an existing post.

# Blog image idea

Image already exists.

# Pre-requisites

- [x] The draft is complete and this post is ready to be reviewed.
- [x] I'm familiar with the [writing for Octopus TL;DR](https://www.octopus.design/writing/writing-tldr/).
- [ ] The PR build passes validation, and if it doesn't, I've checked the [common validations errors](https://style.octopus.com/writing-at-octopus-tldr#common-validation-errors) and none of those apply.
- [x] The images I've included follow the [rules for working with images](https://www.octopus.design/writing/working-with-images/).
- [x] I've added alt text for all the images I've included (alt text describes image to people unable to see it, 125 characters max)
- [x] One screenshot (if any are included) is suitable for Twitter. This screenshot should be 16:9 ratio and at least 1200 x 675 pixels. For screenshots from the Octopus Web Portal, please use Chrome and the browser’s zoom function to remove as much white space as possible. If screenshots are annotated (e.g., with boxes or arrows), please also provide a version that is unannotated for use on Twitter. Do not use dark mode for the Octopus Web Portal.

## How to review this PR

This should enable syntax highlighting for this post and allows us to end-to-end test the changes in Octofront.

## Publication date

Already live.

