### PR TITLE
Free trial link pointing to /start

### DIFF
--- a/blog/2022-02/multi-environment-deployments-jenkins/index.md
+++ b/blog/2022-02/multi-environment-deployments-jenkins/index.md
@@ -219,7 +219,7 @@ In this post, you built a web application using Jenkins, pushed it to the ECR, a
 
 Octopus Deploy provides a dedicated dashboard to view deployments in their different stages. The dashboard highlights how Octopus Deploy supplements a CI tool like Jenkins. 
 
-Octopus Deploy supports all the major cloud providers, including Azure, Google, and Amazon. If you're not already using Octopus, you can start a [free trial](https://octopus.com/).
+Octopus Deploy supports all the major cloud providers, including Azure, Google, and Amazon. If you're not already using Octopus, you can start a [free trial](https://octopus.com/start).
 
 Check out our other posts about deploying with Jenkins, Kubernetes, and Octopus Deploy:
 


### PR DESCRIPTION
This is just a small change as the **free trial** link was pointing to the Octopus home page, rather than the `/start` page.