### PR TITLE
Fix capitalization

### DIFF
--- a/blog/2022-q3/octopus-workflow-builder-feedback/index.md
+++ b/blog/2022-q3/octopus-workflow-builder-feedback/index.md
@@ -55,7 +55,7 @@ We have a [GitHub issue](https://github.com/OctopusSamples/content-team-apps/iss
 
 ## Accessing the source code
 
-If you're interested in the source code for the [WorkFlow Builder](https://octopusworkflowbuilder.octopus.com/#/), we released it on [GitHub](https://github.com/OctopusSamples/content-team-apps).
+If you're interested in the source code for the [Workflow Builder](https://octopusworkflowbuilder.octopus.com/#/), we released it on [GitHub](https://github.com/OctopusSamples/content-team-apps).
 
 ## Conclusion
 


### PR DESCRIPTION
I noticed one sneaky instance of `WorkFlow Builder` with a capital F.