### PR TITLE
Jira Service Management EAP: replace plain Typeform link with shortened link

### DIFF
--- a/blog/2022-09/jira-service-management-eap/index.md
+++ b/blog/2022-09/jira-service-management-eap/index.md
@@ -131,6 +131,6 @@ We look forward to introducing new features to continue supporting your change m
 
 We’d love you to try this integration with your workflow and let us know how we can improve it.
 
-[Register for the Jira Service Management EAP.](https://octopusdeploy.typeform.com/jsm-eap)
+[Register for the Jira Service Management EAP.](https://oc.to/jsm-eap)
 
 Happy deployments!


### PR DESCRIPTION
I've suggested replacing the Typeform link with a shortened URL for better visibility.