### PR TITLE
Syntax highlighting for config as code variables post

### DIFF
--- a/blog/2022-09/config-as-code-variables/index.md
+++ b/blog/2022-09/config-as-code-variables/index.md
@@ -97,7 +97,7 @@ In the first version of Config as Code, we took our existing deployment process 
 
 Variables are passed through the API and persisted as a single-level array of variables. Multi-value variables are persisted as completely separate variables with the same name. Had we just written this directly into the Git repository, the OCL would have looked something like this.
 
-```hcl
+```ruby
 variable "DatabaseName" {
     value = "AU-BNE-TST-001"
     scope = {
@@ -135,7 +135,7 @@ variable "DatabaseName" {
 
 This was functional and the UI worked as expected, but the OCL editing experience wasn't ideal. There were repeated variable names and types, values for the same variable were easily separated, and it created unnecessary nesting. Instead, when serializing to OCL, we merge values for the same variable together, flatten out the scopes, and everything is a lot cleaner.
 
-```hcl
+```ruby
 variable "DatabaseName" {
     value "AU-BNE-TST-001" {
         environment = ["test"]


### PR DESCRIPTION
Hey Tegan,

This is just an update to the post to use the Ruby syntax highlighter, which works for OCL.

It should make this look more readable:

![Current post has no syntax highlighting](https://user-images.githubusercontent.com/99181436/192951169-c8fcd8b8-541f-4121-85cc-df0edf35a1ca.png)

Thanks,

Steve