### PR TITLE
Changed to jira service management call to action to point to the contact page rather than typeform

### DIFF
--- a/blog/2022-09/jira-service-management-eap/index.md
+++ b/blog/2022-09/jira-service-management-eap/index.md
@@ -131,6 +131,6 @@ We look forward to introducing new features to continue supporting your change m
 
 We’d love you to try this integration with your workflow and let us know how we can improve it.
 
-[Register for the Jira Service Management EAP.](https://oc.to/jsm-eap)
+[Contact us to get access to the Jira Service Management EAP](https://octopus.com/company/contact)
 
 Happy deployments!


### PR DESCRIPTION
We want requests for access to JSM to come to the sales team, rather than via the typeform