### PR TITLE
DevOps handbook links: State of DevOps Report 2022

### DIFF
--- a/blog/2022-10/2022-state-of-devops-report/index.md
+++ b/blog/2022-10/2022-state-of-devops-report/index.md
@@ -54,6 +54,6 @@ There are also insights for:
 
 We asked you to participate in the Accelerate State of DevOps survey in some of our newsletters this year. Thank you to everyone who responded and shared their experiences.
 
-You can [read the full report here](https://cloud.google.com/devops/state-of-devops/). [Learn more about DevOps metrics](https://octopus.com/devops/metrics) in the DevOps engineer's handbook.
+You can [read the full report here](https://cloud.google.com/devops/state-of-devops/). Check out the DevOps engineer's handbook to [learn more about DevOps metrics](https://octopus.com/devops/metrics).
 
 Happy deployments!

--- a/blog/2022-10/2022-state-of-devops-report/index.md
+++ b/blog/2022-10/2022-state-of-devops-report/index.md
@@ -54,6 +54,6 @@ There are also insights for:
 
 We asked you to participate in the Accelerate State of DevOps survey in some of our newsletters this year. Thank you to everyone who responded and shared their experiences.
 
-You can [read the full report here](https://cloud.google.com/devops/state-of-devops/).
+You can [read the full report here](https://cloud.google.com/devops/state-of-devops/). [Learn more about DevOps metrics] in the DevOps engineer's handbook.
 
 Happy deployments!

--- a/blog/2022-10/2022-state-of-devops-report/index.md
+++ b/blog/2022-10/2022-state-of-devops-report/index.md
@@ -54,6 +54,6 @@ There are also insights for:
 
 We asked you to participate in the Accelerate State of DevOps survey in some of our newsletters this year. Thank you to everyone who responded and shared their experiences.
 
-You can [read the full report here](https://cloud.google.com/devops/state-of-devops/). [Learn more about DevOps metrics] in the DevOps engineer's handbook.
+You can [read the full report here](https://cloud.google.com/devops/state-of-devops/). [Learn more about DevOps metrics](https://octopus.com/devops/metrics) in the DevOps engineer's handbook.
 
 Happy deployments!


### PR DESCRIPTION
Add relevant links to the DevOps engineer's handbook.