### PR TITLE
Authentication extensions: suggestions

### DIFF
--- a/blog/2022-11/deprecating-authentication-extensions/index.md
+++ b/blog/2022-11/deprecating-authentication-extensions/index.md
@@ -67,7 +67,7 @@ To improve our delivery process and strengthen the safety checks for authenticat
 
 Between now and the end of 2023, we'll continue to support extensions where possible, and review how we can consolidate the custom changes our customers have created into the official providers themselves. 
 
-Based on feedback so far, we anticipate most customizations are only improvements to the existing providers, however we'll investigate the impacts for users with completely custom integrations. Please let us know in the comments below if that includes you.
+Based on feedback so far, we anticipate most customizations are only improvements to the existing providers, however we'll investigate the impacts for users with completely custom integrations. Please let us know if that includes you.
 
 ### Get in touch if the changes impact you
 


### PR DESCRIPTION
I’ve suggested a small change to copy, to remove adjacent duplication of the CTA.

The next bit occurred to me as I read the post, so I’ll share it just in case.

Would it be worth streamlining the CTA to email only? The public comments section may not be a great place to provide hints about customer authentication methods. I know it doesn’t open up customers to being hacked, but it feels like the kind of conversation best had over email.