### PR TITLE
Fix await task version for GH v3 post

### DIFF
--- a/blog/2022-12/github-actions-for-octopus-deploy-v3/index.md
+++ b/blog/2022-12/github-actions-for-octopus-deploy-v3/index.md
@@ -324,7 +324,7 @@ jobs:
 
     steps:
       - name: Waiting for deployment in Octopus Deploy 🐙
-        uses: OctopusDeploy/await-task-action@enh-initialversion
+        uses: OctopusDeploy/await-task-action@v3
         with:
           server_task_id: ${{ matrix.deployment.serverTaskId }}
 ```


### PR DESCRIPTION
Ran into some issues referencing this when testing. Changing to the official v3 release fixed this.
