### PR TITLE
Add comment for blue/green deployment

### DIFF
--- a/blog/2023-04/live-updates-kubernetes-objects-deployments/index.md
+++ b/blog/2023-04/live-updates-kubernetes-objects-deployments/index.md
@@ -83,7 +83,7 @@ For this post, I created the objects in the `octopus` namespace. Please remember
 
 There's a new section added for the Kubernetes Object Status check. I explain these options in more detail shortly.
 
-:::hint We do not support object status checks for deployments that have been configured with [blue/green strategy](https://octopus.com/docs/deployments/kubernetes/deploy-container#bluegreen-deployment-strategy) yet. In such deployments you will not be able to select this option. We plan to add the support soon. :::
+:::hint We do not support object status checks for deployments configured using a [blue/green strategy](https://octopus.com/docs/deployments/kubernetes/deploy-container#bluegreen-deployment-strategy) yet. For these deployments, you can't select this option. We plan to add support soon. :::
 
 ![screenshot showing the Kubernetes object status check configuration section](kubernetes-object-status-check-configuration.png)
 

--- a/blog/2023-04/live-updates-kubernetes-objects-deployments/index.md
+++ b/blog/2023-04/live-updates-kubernetes-objects-deployments/index.md
@@ -83,6 +83,8 @@ For this post, I created the objects in the `octopus` namespace. Please remember
 
 There's a new section added for the Kubernetes Object Status check. I explain these options in more detail shortly.
 
+:::hint We do not support object status checks for deployments that have been configured with [blue/green strategy](https://octopus.com/docs/deployments/kubernetes/deploy-container#bluegreen-deployment-strategy) yet. In such deployments you will not be able to select this option. We plan to add the support soon. :::
+
 ![screenshot showing the Kubernetes object status check configuration section](kubernetes-object-status-check-configuration.png)
 
 For now, you can leave all the default options and it will work.


### PR DESCRIPTION
# About

From the EAP feedback we found quite some customers got confused because they did not see the new object status check option when they are using a blue/green deployment. This PR emphasis this point earlier in the article to provide more clarification.

# Pre-requisites

- [ ] The draft is complete and this post is ready to be reviewed.
- [ ] I'm familiar with the [writing for Octopus TL;DR](https://www.octopus.design/writing/writing-tldr/).
- [ ] The PR build passes validation, and if it doesn't, I've checked the [common validations errors](https://style.octopus.com/writing-at-octopus-tldr#common-validation-errors) and none of those apply.
- [ ] The images I've included follow the [rules for working with images](https://www.octopus.design/writing/working-with-images/).
- [ ] I've added alt text for all the images I've included (alt text describes image to people unable to see it, 125 characters max)
- [ ] One screenshot (if any are included) is suitable for Twitter. This screenshot should be 16:9 ratio and at least 1200 x 675 pixels. For screenshots from the Octopus Web Portal, please use Chrome and the browser’s zoom function to remove as much white space as possible. If screenshots are annotated (e.g., with boxes or arrows), please also provide a version that is unannotated for use on Twitter. Do not use dark mode for the Octopus Web Portal.
- [ ] I've drafted social media posts for Twitter and LinkedIn.

## How to review this PR
<!-- If there's anything you'd like reviewers to focus on, mention it here. -->


## Publication date
<!-- if there are considerations for when to publish this post, mention that here. i.e., this post is supporting material for a webinar I'll be conducting on date, or this post should not published until after a specific release -->

