### PR TITLE
Add internal links to MT use case page

### DIFF
--- a/blog/2021-07/better-multi-tenancy-with-octopus/index.md
+++ b/blog/2021-07/better-multi-tenancy-with-octopus/index.md
@@ -30,7 +30,7 @@ This post assumes knowledge of some key Octopus concepts, including:
 - Variables
 - Lifecycles
 
-If you're new to Octopus, I recommend reading our [Getting started with Octopus guide](https://octopus.com/docs/getting-started). 
+If you're new to Octopus, I recommend reading our [Getting started with Octopus guide](https://octopus.com/docs/getting-started) and [tenanted deployments](https://octopus.com/use-case/tenanted-deployments) use case page. 
 
 To demonstrate how you can model deployments of multiple instances of an application with Octopus, I use a fictitious company called **Vet Clinic**, deploying the Java application, [Pet Clinic](https://github.com/spring-projects/spring-petclinic). 
 

--- a/blog/2021-11/converting-to-tenants-via-api/index.md
+++ b/blog/2021-11/converting-to-tenants-via-api/index.md
@@ -404,7 +404,7 @@ To start using your new tenants with your deployments, you need to set up your [
 
 ## Conclusion
 
-Multi-tenancy in Octopus is a powerful feature that you can leverage to create scalable, reusable, simplified deployments. Converting a sizable existing project to multi-tenancy can seem like a momentous task though. 
+[Multi-tenancy](https://octopus.com/use-case/tenanted-deployments) in Octopus is a powerful feature that you can leverage to create scalable, reusable, simplified deployments. Converting a sizable existing project to multi-tenancy can seem like a momentous task though. 
 
 This post shows a few of the steps to convert an existing project to multi-tenancy. I hope it demonstrates how the Octopus API helps you automate the steps in the process, saving you time and the possibility of hundreds of mouse clicks in the UI.
 


### PR DESCRIPTION
# About

Adding internal links to the multi-tenancy use case page to help search engines discover and improving ranking for the page

# Prerequisites

- [ ] The draft is complete and this post is ready to be reviewed.
- [ ] I'm familiar with the [guide for blog content basics](https://www.octopus.design/932c0f1a9/p/901d2a-blog-content).
- [ ] I've checked the content using Grammarly (Octopus has a corporate license) and the [Hemingway app](https://hemingwayapp.com/) to remove typos, grammatical errors, and passive voice. 
- [ ] The PR build passes validation, and if it doesn't, I've checked the [common validations errors](https://www.octopus.design/932c0f1a9/p/901d2a-blog-content/t/817249) and none of those apply.
- [ ] The images I've included follow the [rules for working with images](https://www.octopus.design/932c0f1a9/p/5061d7-working-with-images).
- [ ] I've added alt text for all the images I've included (alt text describes image to people unable to see it, 125 characters max)
- [ ] I've drafted social media posts for Twitter and LinkedIn and will post them for review in #topic-social-media.
- [ ] I've dropped a note in Slack in #topic-content-marketing to let Tegan Ali know my post is ready for review. (No need to fill out a content brief.)

## How to review this PR

If there's anything you'd like reviewers to focus on, mention it here.


## Publication date

If there are considerations for when to publish this post, mention them here. For example, this post is supporting material for a webinar I'll be conducting on date, or this post should not published until after a specific release on date.

