### PR TITLE
Fix broken link

### DIFF
--- a/blog/2022-03/octopus-release-2022-q1/index.md
+++ b/blog/2022-03/octopus-release-2022-q1/index.md
@@ -305,6 +305,6 @@ We look forward to seeing our customers work with version-controlled projects. W
 
 We'd love to hear from you with any questions or comments. You can leave feedback below or join the conversation in our [Octopus Community Slack](https://octopus.com/slack).
 
-We also invite you to watch our [free webinar, Introducing Config as Code in Octopus](https://octopus.com/events/introducing-config-as-code-in-octopus).
+We also invite you to watch our [free webinar, Introducing Config as Code in Octopus](https://www.youtube.com/watch?v=Z4DgiJ630FU).
 
 Happy (version-controlled) deployments!


### PR DESCRIPTION
Updating link to point to webinar recording on YouTube vs old /events/ directory.



