### PR TITLE
Fix small typo in k8s worker blog

### DIFF
--- a/blog/2024-08/kubernetes-worker/index.md
+++ b/blog/2024-08/kubernetes-worker/index.md
@@ -92,7 +92,7 @@ The installation wizard creates a Kubernetes worker that is appropriate for the 
 
 For the rest, manual customization is available.
 
-You can configure many aspects of the worker my modifying its Helm values. For now, you need to perform these customizations via the command-line using a Helm upgrade command (or setting them manually during install).
+You can configure many aspects of the worker by modifying its Helm values. For now, you need to perform these customizations via the command-line using a Helm upgrade command (or setting them manually during install).
 
 For the full list of customizations, you can refer to the [Helm chart README.md](https://github.com/OctopusDeploy/helm-charts/tree/main/charts/kubernetes-agent).
 


### PR DESCRIPTION
A typo was found in the blog:
<img width="908" alt="image" src="https://github.com/user-attachments/assets/e95134b7-02f1-41fc-91ba-4c7d07146fca">


this solves the issue.